### PR TITLE
Fix #33 + enable day type reset

### DIFF
--- a/lib/screens/event_screen.dart
+++ b/lib/screens/event_screen.dart
@@ -100,6 +100,23 @@ class _EventScreenState extends State<EventScreen> {
     }
   }
 
+  Future<void> _resetDayType() async {
+    setState(() {
+      _log.dayTypeId = null;
+    });
+    await _logService.saveDailyLog(widget.date, _log);
+
+    // Show notification
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Day type reset'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
   Future<void> _editSleepEntry(int index, SleepEntry entry) async {
     await showDialog(
       context: context,
@@ -241,6 +258,7 @@ class _EventScreenState extends State<EventScreen> {
                   backgroundColor: _dayTypes.where((c) => c.id == _log.dayTypeId).firstOrNull?.color.withOpacity(0.1),
                   borderColor: _dayTypes.where((c) => c.id == _log.dayTypeId).firstOrNull?.color,
                   onPressed: _showDayTypeDialog,
+                  onLongPress: _resetDayType,
                 ),
                 const SizedBox(height: 16),
                 _EventButton(
@@ -317,6 +335,7 @@ class _EventButton extends StatelessWidget {
     this.subtitle,
     this.backgroundColor,
     this.borderColor,
+    this.onLongPress,
   });
   final String label;
   final String? subtitle;
@@ -325,6 +344,7 @@ class _EventButton extends StatelessWidget {
   final VoidCallback onPressed;
   final Color? backgroundColor;
   final Color? borderColor;
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -339,6 +359,7 @@ class _EventButton extends StatelessWidget {
         ),
         child: InkWell(
           onTap: onPressed,
+          onLongPress: onLongPress,
           borderRadius: BorderRadius.circular(12.0),
           child: Padding(
             padding: const EdgeInsets.all(16.0),
@@ -379,6 +400,7 @@ class _EventButton extends StatelessWidget {
         elevation: 1.0,
         child: InkWell(
           onTap: onPressed,
+          onLongPress: onLongPress,
           borderRadius: BorderRadius.circular(12.0),
           child: Padding(
             padding: const EdgeInsets.all(16.0),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -402,6 +402,23 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     }
   }
 
+  Future<void> _resetDayType() async {
+    setState(() {
+      _todayLog.dayTypeId = null;
+    });
+    await _logService.saveDailyLog(_loadedDate, _todayLog);
+
+    // Show notification
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Day type reset'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final bool isAsleep = _todayLog.isSleeping;
@@ -586,6 +603,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                     // --- DAY TYPE SELECTOR ---
                     InkWell(
                       onTap: _showDayTypeDialog,
+                      onLongPress: _resetDayType,
                       borderRadius: BorderRadius.circular(16),
                       child: Container(
                         padding: EdgeInsets.symmetric(vertical: 16, horizontal: 20),


### PR DESCRIPTION
- make appearance of day type button (with outline and 0.1 opacity color of the selected daytype) consistent between home and event screen versions of that button (previously that appearance only applied to the home screen). This completely resolves #33 
- add a reset day type functionality to the day type buttons on long-press